### PR TITLE
prepare: do not set termios.OPOST

### DIFF
--- a/pyrepl/unix_console.py
+++ b/pyrepl/unix_console.py
@@ -359,7 +359,6 @@ class UnixConsole(Console):
         raw.iflag |= termios.ICRNL
         raw.iflag &= ~(termios.BRKINT | termios.INPCK |
                        termios.ISTRIP | termios.IXON)
-        raw.oflag &= ~termios.OPOST
         raw.cflag &= ~(termios.CSIZE | termios.PARENB)
         raw.cflag |= (termios.CS8)
         raw.lflag &= ~(termios.ICANON | termios.ECHO |


### PR DESCRIPTION
> OPOST  Enable implementation-defined output processing.

According to [1] this is likely only turning "\n" into "\r\n", which is
required when another thread is dumping output, where currently this
would result into the following with pdb++:

    waited
          waited
                waited
                      (Pdb++) --Return--
                                        > /…/t-threads.py(19)__t2__()->None
                                                                           -> __import__('pdb').pdb.set_trace()

1: https://viewsourcecode.org/snaptoken/kilo/02.enteringRawMode.html#turn-off-all-output-processing

Given `t-threads.py`:
```python
import pdb
import threading

evt = threading.Event()


def __t1__():
    __import__('pdb').set_trace()


def __t2__():
    __import__('pdb').set_trace()


t1 = threading.Thread(target=__t1__)
t1.start()

evt.wait()
t2 = threading.Thread(target=__t2__)
t2.start()

t1.join()
t2.join()
```

Running it looks like this then:

Currently:
```
--Return--
[3] > …/t-threads.py(8)__t1__()->None
-> __import__('pdb').set_trace()
(Pdb++) evt.set()
(Pdb++) --Return--
                  >>> pdb++: waiting for input lock (thread <Thread(Thread-2, started 139812620293888)>)...
                                                                                                           c
>>> pdb++: aquired input lock (thread <Thread(Thread-2, started 139812620293888)>)
[3] > …/t-threads.py(12)__t2__()->None
-> __import__('pdb').set_trace()
(Pdb++) c
```

With this patch:
```
--Return--
[3] > …/t-threads.py(8)__t1__()->None
-> __import__('pdb').set_trace()
(Pdb++) evt.set()
(Pdb++) --Return--
>>> pdb++: waiting for input lock (thread <Thread(Thread-2, started 140056452753152)>)...
c
>>> pdb++: aquired input lock (thread <Thread(Thread-2, started 140056452753152)>)
[3] > …/t-threads.py(12)__t2__()->None
-> __import__('pdb').set_trace()
(Pdb++) c
```

(the ">>> pdb++: waiting for input lock" is something I am currently experimenting with; on top of https://github.com/antocuni/pdb/pull/202)

/cc @mwhudson 
